### PR TITLE
Add missing assert for test "correctly redirects for a file whose fiename contains something looking like a hash"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,10 +128,11 @@ exports.static = function static(directory, options) {
     function dehashifyPath(filePath) {
         var hashRegex = /-[0-9a-f]+(\.[^\.]*$)/;
         var hashMatch = filePath.match(hashRegex);
-
+        var hash = hashMatch[0].slice(1).replace(/\.([^\.]*$)/, '');
+        
         return {
-            path: filePath.replace(hashRegex, '$1'),
-            hash: hashMatch ? hashMatch[0].slice(1).replace(/\.([^\.]*$)/, '') : null
+            path: hash.length==32 ? filePath.replace(hashRegex, '$1') : filePath,
+            hash: hash.length==32 ? hash : null
         };
     }
 

--- a/test/app.js
+++ b/test/app.js
@@ -6,7 +6,12 @@ var app = express();
 
 app.set('views', __dirname + '/views');
 app.set('view engine', 'ejs');
-app.use(electricity.static(__dirname + '/public'));
+
+app.use(
+    electricity.static((__dirname + '/public'), {
+        snockets: { ignore: /compiled/ }
+    })
+);
 
 app.get('/', function(req, res) {
     res.render('index');

--- a/test/index.js
+++ b/test/index.js
@@ -76,12 +76,15 @@ describe('electricity.static', function() {
             assert.throws(function() {
                 electricity.static('test/public', { hostname: {} });
             });
+
             assert.throws(function() {
                 electricity.static('test/public', { hostname: 35 });
             });
+
             assert.throws(function() {
                 electricity.static('test/public', { hostname: function() {} });
             });
+
             assert.throws(function() {
                 electricity.static('test/public', { hostname: [] });
             });
@@ -90,6 +93,7 @@ describe('electricity.static', function() {
             electricity.static('test/public', {
                 hostname: undefined,
                 sass: { imagePath: '/images/' },
+                snockets: { ignore: /compiled/ },
                 watch: { enabled: false }
             });
         });
@@ -114,6 +118,7 @@ describe('electricity.static', function() {
             // Should succeed
             electricity.static('test/public', {
                 sass: { imagePath: undefined },
+                snockets: { ignore: /compiled/ },
                 watch: { enabled: false }
             });
         });

--- a/test/index.js
+++ b/test/index.js
@@ -54,18 +54,21 @@ describe('electricity.static', function() {
         assert.equal(typeof midware, 'function');
         done();
     });
+
     it('should throw if the directory does not exist', function(done) {
         assert.throws(function() {
             electricity.static('test/nope');
         });
         done();
     });
+
     it('should throw if the directory is a file', function(done) {
         assert.throws(function() {
             electricity.static('package.json');
         });
         done();
     });
+
     it('should throw if permissions are insufficent');
 
     describe('with options', function() {
@@ -581,6 +584,7 @@ describe('electricity.static', function() {
         }
 
         it('should gzip the asset contents and send correct encoding header if the client accepts it', gzipTest);
+
         it('should still send gzipped contents after gzipped content is cached', gzipTest);
 
         it('should not gzip non-whitelisted MIME types', function(done) {
@@ -736,6 +740,7 @@ describe('electricity.static', function() {
 
                 defaultMiddleware(req, res, next);
             });
+
             it('uses a given hostname for css url assets', function(done) {
                 var defaultMiddleware = electricity.static('test/public', {
                     hostname: 'example.com',
@@ -769,6 +774,7 @@ describe('electricity.static', function() {
 
                 defaultMiddleware(req, res, next);
             });
+
             it('should work with relative css url\'s', function(done) {
                 var defaultMiddleware = electricity.static('test/public', {
                     snockets: { ignore: 'compiled' },
@@ -888,6 +894,7 @@ describe('electricity.static', function() {
                 };
                 midware(req, res, next);
             });
+
             it('should not compile ignored files', function(done) {
                 var ignoreWare = electricity.static('test/public', {
                     snockets: { ignore: /(main|compiled)/ },
@@ -948,6 +955,7 @@ describe('electricity.static', function() {
                 ignoreWare(req, res, next);
             });
         });
+
         describe('uglifyjs support', function() {
             it('should minify Javascript if enabled', function(done) {
                 var minWare = electricity.static('test/public', {
@@ -984,6 +992,7 @@ describe('electricity.static', function() {
                 minWare(req, res, next);
             });
         });
+
         describe('uglifycss support', function() {
             it('should minify CSS if enabled', function(done) {
                 var minWare = electricity.static('test/public', {
@@ -1016,6 +1025,7 @@ describe('electricity.static', function() {
                 };
                 minWare(req, res, next);
             });
+
             it('should minify compiled CSS if enabled', function(done) {
                 var minWare = electricity.static('test/public', {
                     snockets: { ignore: 'compiled' },

--- a/test/index.js
+++ b/test/index.js
@@ -288,6 +288,7 @@ describe('electricity.static', function() {
                     if (url === '/robots-3e-ca121b5d03245bf82db00d14cee04e22.txt') {
                         redirected = true;
                     }
+                    assert(redirected, 'Did not redirect whose filename contains something looking like a hash');
                     done();
                 },
                 send: function(asset) {


### PR DESCRIPTION
The path provided in the test "/robots-3e.txt" is dehashified to "/robots.txt", which is then hashified to "/robots-ca121b5d03245bf82db00d14cee04e22.txt". This is not  match for the expected url. The added assert now shows a failure.

Either we should change the expected value in the test to "/robots-ca121b5d03245bf82db00d14cee04e22.txt"
_OR_
We should ONLY dehashify urls that contain actual 32 character hashes

I am not certain why we would want to redirect for filenames that have something that looks like a hash, rather than actually having a hash.