### PR TITLE
Fix sass deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.0] - 2025-01-15
+### Changed
+- Switch from `sass.renderSync` to `sass.compile`.
+
+## [3.5.1] - 2024-03-20
+### Changed
+- Bump chokidar from 3.5.0 to 3.6.0
+
 ## [3.5.0] - 2022-12-15
 ### Changed
 - Remove option to eagerly fetch all files in the specified directory (recursively).

--- a/lib/index.js
+++ b/lib/index.js
@@ -160,14 +160,15 @@ exports.static = function(directory, options) {
 
             // SASS
             const basename = path.basename(filePath, path.extname(filePath));
-            options.sass.file = path.join(path.dirname(filePath), `${basename}.scss`);
-            const result = sass.renderSync(options.sass);
-            data = result.css.toString();
+            const sassFile = path.join(path.dirname(filePath), `${basename}.scss`);
+            const result = sass.compile(sassFile, options.sass);
+
+            data = result.css;
 
             // SASS (watcher)
             if (watcher) {
-                result.stats.includedFiles.forEach(file => {
-                    watcher.add(file);
+                result.loadedUrls.forEach(file => {
+                    watcher.add(file.pathname);
                 });
             }
         }

--- a/package.json
+++ b/package.json
@@ -34,5 +34,5 @@
     "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "test": "mocha --exit -R spec"
   },
-  "version": "3.5.1"
+  "version": "3.6.0"
 }


### PR DESCRIPTION
Our downstream projects get many deprecation warnings from SASS. Many of them are due to our files using `@import` which was marked as deprecated in October 2024. That is a matter for the downstream projects to sort out. However, another warning is due to `renderSync` deprecation. We are switching that over to `compile` which takes care of the warning.